### PR TITLE
Fix errors when plugin doesn't exist

### DIFF
--- a/src/main/java/zen/luckchat/LuckChatPlugin.java
+++ b/src/main/java/zen/luckchat/LuckChatPlugin.java
@@ -30,7 +30,7 @@ public class LuckChatPlugin extends PluginBase implements Listener {
         // Get LuckPerms API
         try {
             luckPerms = LuckPerms.getApiSafe().orElse(null);
-        } catch (Exception e) {
+        } catch (Throwable e) {
             // ignore
         }
         if (luckPerms == null) {
@@ -42,14 +42,14 @@ public class LuckChatPlugin extends PluginBase implements Listener {
         // Check for Placeholder API
         try {
             placeholderApi = PlaceholderAPI.getInstance();
-        } catch (Exception e) {
+        } catch (Throwable e) {
             // ignore
         }
 
         // Check for Factions
         try {
             factions = P.p;
-        } catch (Exception e) {
+        } catch (Throwable e) {
             // ignore
         }
 


### PR DESCRIPTION
Change `Exception` to `Throwable` so we can stop any ClassDef Errors or anything else we don't want to stop the server.